### PR TITLE
Update shopee_checkin.js

### DIFF
--- a/scripts/shopee_checkin.js
+++ b/scripts/shopee_checkin.js
@@ -58,7 +58,7 @@ async function checkin() {
   return new Promise((resolve, reject) => {
     try {
       const request = {
-        url: 'https://shopee.tw/mkt/coins/api/v2/checkin',
+        url: 'https://shopee.tw/mkt/coins/api/v2/checkin_new',
         headers: config.shopeeHeaders,
       };
 


### PR DESCRIPTION
Because the recent daily check-in URL for Shopee has changed, after verification, it is found that "_new" is added at the end of the original URL.

<img width="747" alt="image" src="https://github.com/Black-Magic-Lab/Surge/assets/1209862/829b1280-be59-4163-9f14-e0d7b83cbdbc">
